### PR TITLE
Fix for finding links with given content

### DIFF
--- a/server/sctp/client.py
+++ b/server/sctp/client.py
@@ -293,7 +293,7 @@ class SctpClient:
         for i in xrange(resCount):
             addr = ScAddr(0, 0)
             data = data[4:]
-            addr.seg, addr.offset = struct.unpack('=HH', data)
+            addr.seg, addr.offset = struct.unpack('=HH', data[:4])
             res.append(addr)
 
         return res


### PR DESCRIPTION
The find_links_with_content() function in python sctp client was incorrectly handling sctp-server responses with multiple sc-links. This also affected NL question-answering functionality.
